### PR TITLE
Optimized publish task

### DIFF
--- a/CHANGES/93.bugfix
+++ b/CHANGES/93.bugfix
@@ -1,0 +1,1 @@
+Optimized publish task to be significantly faster.

--- a/pulp_gem/app/models.py
+++ b/pulp_gem/app/models.py
@@ -32,6 +32,16 @@ class GemContent(Content):
     name = models.TextField(blank=False, null=False)
     version = models.TextField(blank=False, null=False)
 
+    @property
+    def relative_path(self):
+        """The relative path this gem is stored under for the content app."""
+        return f"gems/{self.name}-{self.version}.gem"
+
+    @property
+    def gemspec_path(self):
+        """The path for this gem's gemspec for the content app."""
+        return f"quick/Marshal.4.8/{self.name}-{self.version}.gemspec.rz"
+
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"
         unique_together = ("name", "version")

--- a/pulp_gem/app/tasks/publishing.py
+++ b/pulp_gem/app/tasks/publishing.py
@@ -2,20 +2,40 @@ import logging
 import re
 import gzip
 import shutil
-import tempfile
 
 from gettext import gettext as _
 from packaging import version
 
 from django.core.files import File
+from jinja2 import Template
+from pathlib import Path
 
-from pulpcore.plugin.models import RepositoryVersion, PublishedArtifact, PublishedMetadata
+from pulpcore.plugin.models import RepositoryVersion, PublishedMetadata
 
 from pulp_gem.app.models import GemContent, GemPublication
 from pulp_gem.specs import write_specs, Key
 
 
 log = logging.getLogger(__name__)
+
+
+index_template = """<!DOCTYPE html>
+<html>
+  <head>
+    {% if path -%}
+    <title>Index of {{ path }}</title>
+    {% else -%}
+    <title>Gem Index</title>
+    {% endif -%}
+  </head>
+  <body>
+    <a href="../">../</a><br/>
+    {% for link in links %}
+    <a href="{{ link|e }}">{{ link|e }}</a><br/>
+    {% endfor %}
+  </body>
+</html>
+"""
 
 
 def _publish_specs(specs, relative_path, publication):
@@ -33,6 +53,22 @@ def _publish_specs(specs, relative_path, publication):
     specs_metadata_gz.save()
 
 
+def _create_index(publication, path="", links=None):
+    links = links or []
+    links = (li if li.endswith("/") else str(Path(li).relative_to(path)) for li in links)
+    template = Template(index_template)
+    index_path = f"{path}index.html"
+    if path:
+        Path(path).mkdir(exist_ok=True)
+    with open(index_path, "w") as index:
+        index.write(template.render(links=links, path=path))
+
+    index_metadata = PublishedMetadata.create_from_file(
+        relative_path=index_path, publication=publication, file=File(open(index_path, "rb"))
+    )
+    index_metadata.save()
+
+
 def publish(repository_version_pk):
     """
     Create a Publication based on a RepositoryVersion.
@@ -48,32 +84,45 @@ def publish(repository_version_pk):
             repo=repository_version.repository.name, ver=repository_version.number
         )
     )
-    with tempfile.TemporaryDirectory("."):
-        with GemPublication.create(repository_version) as publication:
-            specs = []
-            latest_versions = {}
-            prerelease_specs = []
-            for content in GemContent.objects.filter(
-                pk__in=publication.repository_version.content
-            ).order_by("-pulp_created"):
-                for content_artifact in content.contentartifact_set.all():
-                    published_artifact = PublishedArtifact(
-                        relative_path=content_artifact.relative_path,
-                        publication=publication,
-                        content_artifact=content_artifact,
-                    )
-                    published_artifact.save()
-                if re.fullmatch(r"[0-9.]*", content.version):
-                    specs.append(Key(content.name, content.version))
-                    old_ver = latest_versions.get(content.name)
-                    if old_ver is None or version.parse(old_ver) < version.parse(content.version):
-                        latest_versions[content.name] = content.version
-                else:
-                    prerelease_specs.append(Key(content.name, content.version))
-            latest_specs = [Key(name, version) for name, version in latest_versions.items()]
+    with GemPublication.create(repository_version, pass_through=True) as publication:
+        specs = []
+        latest_versions = {}
+        prerelease_specs = []
+        gems = []
+        gemspecs = []
+        for content in (
+            GemContent.objects.filter(pk__in=publication.repository_version.content)
+            .only("name", "version")
+            .order_by("-pulp_created")
+            .iterator()
+        ):
+            if re.fullmatch(r"[0-9.]*", content.version):
+                specs.append(Key(content.name, content.version))
+                old_ver = latest_versions.get(content.name)
+                if old_ver is None or version.parse(old_ver) < version.parse(content.version):
+                    latest_versions[content.name] = content.version
+            else:
+                prerelease_specs.append(Key(content.name, content.version))
+            gems.append(content.relative_path)
+            gemspecs.append(content.gemspec_path)
+        latest_specs = [Key(name, ver) for name, ver in latest_versions.items()]
 
-            _publish_specs(specs, "specs.4.8", publication)
-            _publish_specs(latest_specs, "latest_specs.4.8", publication)
-            _publish_specs(prerelease_specs, "prerelease_specs.4.8", publication)
+        _publish_specs(specs, "specs.4.8", publication)
+        _publish_specs(latest_specs, "latest_specs.4.8", publication)
+        _publish_specs(prerelease_specs, "prerelease_specs.4.8", publication)
+        _create_index(
+            publication,
+            path="",
+            links=[
+                "gems/",
+                "quick/Marshal.4.8/",
+                "specs.4.8",
+                "latest_specs.4.8",
+                "prerelease_specs.4.8",
+            ],
+        )
+        _create_index(publication, path="gems/", links=gems)
+        _create_index(publication, path="quick/", links=[])
+        _create_index(publication, path="quick/Marshal.4.8/", links=gemspecs)
 
     log.info(_("Publication: {publication} created").format(publication=publication.pk))


### PR DESCRIPTION
Publish task now uses `pass_through=True` and creates index pages for all possible routes to speed up content app browsing.

On a full sync of rubygems.org, publish task speed up: 1hr 10min -> 2 min.  We are no longer performing roughly 2mil db saves, just saves for the 6 (3x2) metadata and 4 index files. Also, browsing to the base_url of the repository is now much faster that the index has been pre-computed which is important since the `gem` tooling performs a `HEAD` request to the index before fetching files and the current content-app is un-optimized to generate an index page with millions of links. 

fixes: https://github.com/pulp/pulp_gem/issues/93