### PR TITLE
Require pulpcore >=3.39

### DIFF
--- a/CHANGES/+bump_pulpcore.removal
+++ b/CHANGES/+bump_pulpcore.removal
@@ -1,0 +1,1 @@
+Bumped the requirement on pulpcore to >=3.39 as the next supported version in the line.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pulpcore>=3.34.0,<3.54
+pulpcore>=3.39.0,<3.54
 rubymarshal>=1.2.7,<1.3


### PR DESCRIPTION
There are some testing facilities missing in 3.34 but that branch is abandoned. 3.39 is the next supported one in line.

[noissue]