### PR TITLE
Fix pulpcore upperbound requirement to be <3.55

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pulpcore>=3.39.0,<3.54
+pulpcore>=3.39.0,<3.55
 pulp_glue_gem>=0.3.0,<0.4.0
 rubymarshal>=1.2.7,<1.3


### PR DESCRIPTION
Nightly pulp-oci-images are failing since this plugin has the wrong upperbound compared to the other plugins. Maybe we should also backport it?