### PR TITLE
fix(docs): default sources need to be cleared before defining a new source

### DIFF
--- a/docs/user/guides/cache.md
+++ b/docs/user/guides/cache.md
@@ -78,8 +78,7 @@ Use the Gem Distribution's `base_url` as the value for the `--source` parameter.
 
 === "run"
     ```bash
-    gem install --source http://localhost:5001/pulp/content/rubygems/ \
-      --clear-sources pulpcore_client
+    gem install --clear-sources --source http://localhost:5001/pulp/content/rubygems/ pulpcore_client
     ```
 === "output"
     ```bash


### PR DESCRIPTION
Adding `--clear-sources` after adding `--source` immediately clears the source list so that gem fall backs to the default source and the pulp source is never actually used.

Just adding `--source` adds the pulp server as a fall back to the default source.

By clearing the sources first and then adding the pulp server as a source ensures that it's the only mirror that's used.