### PR TITLE
Fixed parsing versions file with missing checksum

### DIFF
--- a/CHANGES/313.bugfix
+++ b/CHANGES/313.bugfix
@@ -1,0 +1,1 @@
+Fixed handling somewhat inconsistent metadata on rubygems.org where an md5 checksum is missing in the versions file.

--- a/pulp_gem/app/tasks/synchronizing.py
+++ b/pulp_gem/app/tasks/synchronizing.py
@@ -188,6 +188,9 @@ class GemFirstStage(Stage):
                     info_url = urljoin(urljoin(self.remote.url, "info/"), name)
                     if "md5" in settings.ALLOWED_CONTENT_CHECKSUMS:
                         extra_kwargs = {"expected_digests": {"md5": md5_sum}}
+                    elif md5_sum is None:
+                        extra_kwargs = {}
+                        log.warn(f"Checksum of info file for '{name}' was not provided.")
                     else:
                         extra_kwargs = {}
                         log.warn(f"Checksum of info file for '{name}' could not be validated.")

--- a/pulp_gem/specs.py
+++ b/pulp_gem/specs.py
@@ -108,7 +108,11 @@ async def read_versions(relative_path):
                 continue
             if preamble:
                 continue
-            name, versions_str, md5_sum = line.split(" ", maxsplit=2)
+            # Dirty trick to make the md5sum default to None
+            split_line = line.split(" ", maxsplit=2) + [None]
+            name = split_line[0]
+            versions_str = split_line[1]
+            md5_sum = split_line[2]
             ext_versions = versions_str.split(",")
             entry = results.get(name) or ([], "")
             results[name] = (entry[0] + ext_versions, md5_sum)


### PR DESCRIPTION
At some point in time, rubygems.org was shipping a versions file where the md5 checksum is missing on one line. We will just ignore this and sync the content anyway.

fixes #313