### PR TITLE
Fix a bug in determining deferred validation

### DIFF
--- a/CHANGES/+upload.bugfix
+++ b/CHANGES/+upload.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug where upload fails due to improperly determining deferred serialization.

--- a/pulp_gem/app/serializers.py
+++ b/pulp_gem/app/serializers.py
@@ -103,7 +103,7 @@ class GemContentSerializer(MultipleArtifactContentSerializer):
         elif "artifact" not in data:
             raise ValidationError(_("One of 'file' and 'artifact' must be specified."))
 
-        if "request" not in self.context:
+        if self.context.get("request") is None:
             data = self.deferred_validate(data)
 
         return data


### PR DESCRIPTION
With a recent change, even in the deferred context, the "request" will be set on the context. So we need to compair to None instead of just looking for existance.