### PR TITLE
Fix colon split in read_info() causing sync failure

### DIFF
--- a/CHANGES/446.bugfix
+++ b/CHANGES/446.bugfix
@@ -1,0 +1,1 @@
+Fixed sync failure on gems with colons in dependency specs (e.g., rails).

--- a/pulp_gem/specs.py
+++ b/pulp_gem/specs.py
@@ -157,7 +157,7 @@ async def read_info(relative_path, versions_info):
                     (item.split(":", maxsplit=1) for item in dependencies.split(","))
                 )
             for stmt in back.split(","):
-                key, value = stmt.split(":")
+                key, value = stmt.split(":", 1)
                 if key == "checksum":
                     gem_info["checksum"] = value
                 elif key == "ruby":

--- a/pulp_gem/tests/unit/test_spec.py
+++ b/pulp_gem/tests/unit/test_spec.py
@@ -1,4 +1,6 @@
-from pulp_gem.specs import ruby_ver_cmp, ruby_ver_includes
+import asyncio
+
+from pulp_gem.specs import read_info, ruby_ver_cmp, ruby_ver_includes
 
 
 def test_version_cmp():
@@ -20,3 +22,21 @@ def test_version_includes():
     assert ruby_ver_includes(">= 1&< 3", "1.5.a0")
     assert ruby_ver_includes(">= 1&< 3", "3.0.0a5")
     assert not ruby_ver_includes(">= 1&< 3", "3.0.1a5")
+
+
+def test_read_info_colon_in_value(tmp_path):
+    info_file = tmp_path / "info"
+    info_file.write_text(
+        "---\n7.0.1 activesupport:= 7.0.1|checksum:abc123,ruby:>= 2.7.0,rubygems:>= 1.8.11\n"
+    )
+    versions_info = {"7.0.1": {"version": "7.0.1", "platform": "ruby", "prerelease": False}}
+
+    async def _collect():
+        return [info async for info in read_info(str(info_file), versions_info)]
+
+    results = asyncio.run(_collect())
+    assert len(results) == 1
+    assert results[0]["checksum"] == "abc123"
+    assert results[0]["required_ruby_version"] == ">= 2.7.0"
+    assert results[0]["required_rubygems_version"] == ">= 1.8.11"
+    assert results[0]["dependencies"] == {"activesupport": "= 7.0.1"}

--- a/pulp_gem/tests/unit/test_spec.py
+++ b/pulp_gem/tests/unit/test_spec.py
@@ -27,7 +27,7 @@ def test_version_includes():
 def test_read_info_colon_in_value(tmp_path):
     info_file = tmp_path / "info"
     info_file.write_text(
-        "---\n7.0.1 activesupport:= 7.0.1|checksum:abc123,ruby:>= 2.7.0,rubygems:>= 1.8.11\n"
+        "---\n7.0.1 activesupport:= 7.0.1|checksum:abc123,ruby:>= 2.7.0,rubygems:>= 1.8.11,created_at:2009-07-25T18:01:49Z\n"
     )
     versions_info = {"7.0.1": {"version": "7.0.1", "platform": "ruby", "prerelease": False}}
 


### PR DESCRIPTION
Fixes #446

`stmt.split(":")` in `read_info()` fails with `ValueError` when values contain colons. Added `maxsplit=1`, matching the pattern already used on line 157.